### PR TITLE
Now able to grab Merchant username

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,7 +5,7 @@ class Merchant < ActiveRecord::Base
     merchant       = Merchant.new
     merchant.uid   = auth_hash[:uid].to_i
     merchant.provider = 'github'
-    merchant.username  = auth_hash['info']['name']
+    merchant.username  = auth_hash['info']['nickname']
     merchant.email = auth_hash['info']['email']
     merchant.save
 


### PR DESCRIPTION
Fixed issue with the name field in Github auth hash coming across as nil -> instead we should use nickname, as that's what users log into Github with (not everyone sets a name field). We'll instead use Brandi's Merchant edit form to have them set a Merchant Name. 
