### PR TITLE
added default merchant name

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,6 +7,7 @@ class Merchant < ActiveRecord::Base
     merchant.provider = 'github'
     merchant.username  = auth_hash['info']['nickname']
     merchant.email = auth_hash['info']['email']
+    merchant.displayname = 'My Merchant'
     merchant.save
 
     return merchant


### PR DESCRIPTION
Small change-  prevents an ugly path name from showing up if a new merchant logs in and doesn't immediately set their merchant name.
